### PR TITLE
[Auto] Increase k8s node_count to 5

### DIFF
--- a/envs/staging/k8s/variables.tf
+++ b/envs/staging/k8s/variables.tf
@@ -10,7 +10,7 @@ variable "k8s_version" {
 
 variable "node_count" {
   type    = number
-  default = 3
+  default = 5
 }
 
 variable "instance_type" {


### PR DESCRIPTION
## Why
- Alert: (n/a) (sev: n/a)
- Hypothesis: Increase cluster capacity to absorb traffic spike

## What changed
- Target: `envs/staging/k8s` / file: `envs/staging/k8s/variables.tf`
- Edit: `node_count = 5` (single minimal change)

## Safety
- Policy pre-checks: precheck ok
- Blast radius: single variable
- Rollback: revert this commit or set `node_count = unknown`

## Verification
- Expect 5xx rate to improve within 30m.